### PR TITLE
Fix typos and clarify branch naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ Do not attempt to commit or push directly to ```main```.
 Before starting work:
 Pull the latest updates to ```main```, then create a new branch and name your branch clearly. For example:
 ```subsystem-arm-pid-tuning```
-```bugfix-xbox-utton-not-working```
+```bugfix-xbox-button-not-working```
 ```docs-update-readme```
 
 Once your work is complete, open a new Pull Request and check against this list:
 - Add vishnu09bharath as a reviewer.
   - Optionally, request the `software-leads` team to review. All pull requests must be approved by only vishnu09bharath, but feedback/improvement suggestions may be delegated to other software leads.
 - Code has thorough documentation in the form of comments, or where necessary, in the ```README```.
-- All public methods include method descriptions for intellisense.
+- All public methods include method descriptions for intellisense where useful (custom utils, state params, etc.).
 - The code passes the [FRC 190 Code Standards](https://team-190.github.io/190-Robot-Code-Standards/ROBOTSTATE_STANDARDS) for the relevant type (subsystem, command, etc.) and all global standards.
 - Code inspired by other teams/examples is credited for future reference.
 - The latest commit passes all build checks.
 - All merge conflicts are resolved.
 
 ### During Competitions
-All competitions, whether pre-season, season, or off-season, will be given their own branch designated with the event code and year. Ex: ```MAWOR2025```. These branches are unprotected and have no rulesets associated with them. All code deployed to the competition robot will be sourced from this designated branch. This allows any member to push code without requiring a pull request, allowing for faster, hassle-free changes to robot code. After each competition, the branch will be merged with ```main``` without squashing commits, given it is in a working state.
+All competitions, whether pre-season, season, or off-season, will be given their own branch designated with the event code and year. Ex: ```event_MAWOR2025```. These branches are unprotected and have no rulesets associated with them. All code deployed to the competition robot will be sourced from this designated branch. This allows any member to push code without requiring a pull request, allowing for faster, hassle-free changes to robot code. After each competition, the branch will be merged with ```main``` without squashing commits, given it is in a working state.
 
 ### Additional Notes
 


### PR DESCRIPTION
Corrected a typo in the branch naming example and clarified the competition branch naming convention.