### PR TITLE
Remove Deprecated Phoenix 6 Warnings

### DIFF
--- a/src/main/java/org/neiacademy/robotics/BuildConstants.java
+++ b/src/main/java/org/neiacademy/robotics/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "2026-Robot-Code";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 222;
-  public static final String GIT_SHA = "5f9ac721f27ee39d4f970873fb8ab4ef444af90e";
-  public static final String GIT_DATE = "2026-06-02 16:27:14 EDT";
-  public static final String GIT_BRANCH = "torque-current-foc";
-  public static final String BUILD_DATE = "2026-06-02 16:40:18 EDT";
-  public static final long BUILD_UNIX_TIME = 1780432818191L;
+  public static final int GIT_REVISION = 229;
+  public static final String GIT_SHA = "e30343d1bf9496a978692e31afaf3b7995629148";
+  public static final String GIT_DATE = "2026-06-02 20:30:35 EDT";
+  public static final String GIT_BRANCH = "HEAD";
+  public static final String BUILD_DATE = "2026-06-02 20:55:21 EDT";
+  public static final long BUILD_UNIX_TIME = 1780448121625L;
   public static final int DIRTY = 1;
 
   private BuildConstants() {}

--- a/src/main/java/org/neiacademy/robotics/frc2026/Constants.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/Constants.java
@@ -62,19 +62,31 @@ public final class Constants {
   }
 
   public static class Drive {
-    public static final LoggedTunableNumber STEER_kP = new LoggedTunableNumber("PID/Drive/Steer/kP", 3600);
-    public static final LoggedTunableNumber STEER_kI = new LoggedTunableNumber("PID/Drive/Steer/kI", 0);
-    public static final LoggedTunableNumber STEER_kD = new LoggedTunableNumber("PID/Drive/Steer/kD", 70);
-    public static final LoggedTunableNumber STEER_kS = new LoggedTunableNumber("PID/Drive/Steer/kS", 0);
-    public static final LoggedTunableNumber STEER_kV = new LoggedTunableNumber("PID/Drive/Steer/kV", 0);
-    public static final LoggedTunableNumber STEER_kA = new LoggedTunableNumber("PID/Drive/Steer/kA", 0);
+    public static final LoggedTunableNumber STEER_kP =
+        new LoggedTunableNumber("PID/Drive/Steer/kP", 3600);
+    public static final LoggedTunableNumber STEER_kI =
+        new LoggedTunableNumber("PID/Drive/Steer/kI", 0);
+    public static final LoggedTunableNumber STEER_kD =
+        new LoggedTunableNumber("PID/Drive/Steer/kD", 70);
+    public static final LoggedTunableNumber STEER_kS =
+        new LoggedTunableNumber("PID/Drive/Steer/kS", 0);
+    public static final LoggedTunableNumber STEER_kV =
+        new LoggedTunableNumber("PID/Drive/Steer/kV", 0);
+    public static final LoggedTunableNumber STEER_kA =
+        new LoggedTunableNumber("PID/Drive/Steer/kA", 0);
 
-    public static final LoggedTunableNumber DRIVE_kP = new LoggedTunableNumber("PID/Drive/Propulsion/kP", 40);
-    public static final LoggedTunableNumber DRIVE_kI = new LoggedTunableNumber("PID/Drive/Propulsion/kI", 0);
-    public static final LoggedTunableNumber DRIVE_kD = new LoggedTunableNumber("PID/Drive/Propulsion/kD", 0);
-    public static final LoggedTunableNumber DRIVE_kS = new LoggedTunableNumber("PID/Drive/Propulsion/kS", 8);
-    public static final LoggedTunableNumber DRIVE_kV = new LoggedTunableNumber("PID/Drive/Propulsion/kV", 0.4);
-    public static final LoggedTunableNumber DRIVE_kA = new LoggedTunableNumber("PID/Drive/Propulsion/kA", 0);
+    public static final LoggedTunableNumber DRIVE_kP =
+        new LoggedTunableNumber("PID/Drive/Propulsion/kP", 40);
+    public static final LoggedTunableNumber DRIVE_kI =
+        new LoggedTunableNumber("PID/Drive/Propulsion/kI", 0);
+    public static final LoggedTunableNumber DRIVE_kD =
+        new LoggedTunableNumber("PID/Drive/Propulsion/kD", 0);
+    public static final LoggedTunableNumber DRIVE_kS =
+        new LoggedTunableNumber("PID/Drive/Propulsion/kS", 8);
+    public static final LoggedTunableNumber DRIVE_kV =
+        new LoggedTunableNumber("PID/Drive/Propulsion/kV", 0.4);
+    public static final LoggedTunableNumber DRIVE_kA =
+        new LoggedTunableNumber("PID/Drive/Propulsion/kA", 0);
   }
 
   public static class Intake {

--- a/src/main/java/org/neiacademy/robotics/frc2026/Robot.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/Robot.java
@@ -143,7 +143,7 @@ public class Robot extends LoggedRobot {
 
     // schedule the autonomous command (example)
     if (autonomousCommand != null) {
-      autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(autonomousCommand);
     }
   }
 

--- a/src/main/java/org/neiacademy/robotics/frc2026/subsystems/drive/GyroIOPigeon2.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/subsystems/drive/GyroIOPigeon2.java
@@ -22,9 +22,7 @@ import org.neiacademy.robotics.frc2026.generated.TunerConstants;
 /** IO implementation for Pigeon 2. */
 public class GyroIOPigeon2 implements GyroIO {
   private final Pigeon2 pigeon =
-      new Pigeon2(
-          TunerConstants.DrivetrainConstants.Pigeon2Id,
-          TunerConstants.DrivetrainConstants.CANBusName);
+      new Pigeon2(TunerConstants.DrivetrainConstants.Pigeon2Id, TunerConstants.kCANBus);
   private final StatusSignal<Angle> yaw = pigeon.getYaw();
   private final Queue<Double> yawPositionQueue;
   private final Queue<Double> yawTimestampQueue;

--- a/src/main/java/org/neiacademy/robotics/frc2026/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/subsystems/drive/ModuleIOTalonFX.java
@@ -96,9 +96,9 @@ public class ModuleIOTalonFX implements ModuleIO {
       SwerveModuleConstants<TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration>
           constants) {
     this.constants = constants;
-    driveTalon = new TalonFX(constants.DriveMotorId, TunerConstants.DrivetrainConstants.CANBusName);
-    turnTalon = new TalonFX(constants.SteerMotorId, TunerConstants.DrivetrainConstants.CANBusName);
-    cancoder = new CANcoder(constants.EncoderId, TunerConstants.DrivetrainConstants.CANBusName);
+    driveTalon = new TalonFX(constants.DriveMotorId, TunerConstants.kCANBus);
+    turnTalon = new TalonFX(constants.SteerMotorId, TunerConstants.kCANBus);
+    cancoder = new CANcoder(constants.EncoderId, TunerConstants.kCANBus);
 
     // Configure drive motor
     var driveConfig = constants.DriveMotorInitialConfigs;

--- a/src/main/java/org/neiacademy/robotics/frc2026/subsystems/intakedeploy/IntakeDeployIOTalonFX.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/subsystems/intakedeploy/IntakeDeployIOTalonFX.java
@@ -48,10 +48,10 @@ public class IntakeDeployIOTalonFX implements IntakeDeployIO {
   public IntakeDeployIOTalonFX() {
     deploy =
         new TalonFX(
-            Constants.Intake.DEPLOY_MOTOR_ID.getID(), Constants.Intake.DEPLOY_MOTOR_ID.getBus());
+            Constants.Intake.DEPLOY_MOTOR_ID.getID(), Constants.Intake.DEPLOY_MOTOR_ID.getCANBus());
 
     cancoder =
-        new CANcoder(Constants.Intake.ENCODER_ID.getID(), Constants.Intake.ENCODER_ID.getBus());
+        new CANcoder(Constants.Intake.ENCODER_ID.getID(), Constants.Intake.ENCODER_ID.getCANBus());
     deployConfig = new TalonFXConfiguration();
 
     deployConfig.CurrentLimits.StatorCurrentLimitEnable = true;
@@ -206,9 +206,7 @@ public class IntakeDeployIOTalonFX implements IntakeDeployIO {
 
   private void resetProfileToCurrentState() {
     profileSetpoint =
-        new TrapezoidProfile.State(
-            rotorPosition.getValueAsDouble(),
-            velocity.getValueAsDouble());
+        new TrapezoidProfile.State(rotorPosition.getValueAsDouble(), velocity.getValueAsDouble());
     profileInitialized = true;
   }
 }

--- a/src/main/java/org/neiacademy/robotics/frc2026/subsystems/intakeroller/IntakeRollerIOTalonFX.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/subsystems/intakeroller/IntakeRollerIOTalonFX.java
@@ -32,7 +32,7 @@ public class IntakeRollerIOTalonFX implements IntakeRollerIO {
   public IntakeRollerIOTalonFX() {
     roller =
         new TalonFX(
-            Constants.Intake.ROLLER_MOTOR_ID.getID(), Constants.Intake.ROLLER_MOTOR_ID.getBus());
+            Constants.Intake.ROLLER_MOTOR_ID.getID(), Constants.Intake.ROLLER_MOTOR_ID.getCANBus());
 
     rollerConfig = new TalonFXConfiguration();
 

--- a/src/main/java/org/neiacademy/robotics/frc2026/subsystems/loader/LoaderIOTalonFX.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/subsystems/loader/LoaderIOTalonFX.java
@@ -30,7 +30,7 @@ public class LoaderIOTalonFX implements LoaderIO {
   private final StatusSignal<Current> supplyCurrent;
 
   public LoaderIOTalonFX() {
-    loader = new TalonFX(Constants.Loader.MOTOR_ID.getID(), Constants.Loader.MOTOR_ID.getBus());
+    loader = new TalonFX(Constants.Loader.MOTOR_ID.getID(), Constants.Loader.MOTOR_ID.getCANBus());
     config = new TalonFXConfiguration();
 
     config.CurrentLimits.StatorCurrentLimitEnable = true;

--- a/src/main/java/org/neiacademy/robotics/frc2026/subsystems/shooter/ShooterIOTalonFX.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/subsystems/shooter/ShooterIOTalonFX.java
@@ -46,8 +46,8 @@ public class ShooterIOTalonFX implements ShooterIO {
 
   public ShooterIOTalonFX(
       boolean isLeftShooter, CANDeviceID leader, CANDeviceID follower, boolean opposed) {
-    shooterLeader = new TalonFX(leader.getID(), leader.getBus());
-    shooterFollower = new TalonFX(follower.getID(), follower.getBus());
+    shooterLeader = new TalonFX(leader.getID(), leader.getCANBus());
+    shooterFollower = new TalonFX(follower.getID(), follower.getCANBus());
     if (opposed) {
       shooterFollower.setControl(new Follower(leader.getID(), MotorAlignmentValue.Opposed));
 

--- a/src/main/java/org/neiacademy/robotics/frc2026/subsystems/spindexer/SpindexerIOTalonFX.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/subsystems/spindexer/SpindexerIOTalonFX.java
@@ -31,7 +31,7 @@ public class SpindexerIOTalonFX implements SpindexerIO {
 
   public SpindexerIOTalonFX() {
     spindexer =
-        new TalonFX(Constants.Spindexer.MOTOR_ID.getID(), Constants.Spindexer.MOTOR_ID.getBus());
+        new TalonFX(Constants.Spindexer.MOTOR_ID.getID(), Constants.Spindexer.MOTOR_ID.getCANBus());
     config = new TalonFXConfiguration();
 
     config.CurrentLimits.StatorCurrentLimitEnable = true;

--- a/src/main/java/org/neiacademy/robotics/frc2026/util/drivers/CANDeviceID.java
+++ b/src/main/java/org/neiacademy/robotics/frc2026/util/drivers/CANDeviceID.java
@@ -7,7 +7,14 @@
 
 package org.neiacademy.robotics.frc2026.util.drivers;
 
+import com.ctre.phoenix6.CANBus;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.neiacademy.robotics.frc2026.generated.TunerConstants;
+
 public class CANDeviceID {
+  private static final Map<String, CANBus> CAN_BUSES = new ConcurrentHashMap<>();
+
   private final int deviceNumber;
   private final String bus;
 
@@ -27,6 +34,17 @@ public class CANDeviceID {
 
   public String getBus() {
     return bus;
+  }
+
+  public CANBus getCANBus() {
+    if (bus.equals("Drive")) {
+      return TunerConstants.kCANBus;
+    }
+    return CAN_BUSES.computeIfAbsent(bus, CANDeviceID::createCANBus);
+  }
+
+  private static CANBus createCANBus(String bus) {
+    return bus.equals("rio") ? CANBus.roboRIO() : new CANBus(bus);
   }
 
   @SuppressWarnings("NonOverridingEquals")


### PR DESCRIPTION
## Summary
- Replace deprecated `Command.schedule()` with `CommandScheduler.getInstance().schedule(...)`.
- Migrate CTRE hardware construction to `CANBus`-based overloads for TalonFX, CANcoder, and Pigeon2.
- Add `CANDeviceID.getCANBus()` with caching and a case-sensitive `"Drive"` special case that returns `TunerConstants.kCANBus`.

## Testing
- `env JAVA_HOME=/Users/vishnubharath/wpilib/2026/jdk ./gradlew --no-daemon build` passed.
- Spotless formatting and compile tasks completed successfully during the build.